### PR TITLE
Temp fix: datetime formatting when no date or no time

### DIFF
--- a/ckanext/datatablesview_plus/assets/datatablesview_plus.js
+++ b/ckanext/datatablesview_plus/assets/datatablesview_plus.js
@@ -98,7 +98,19 @@ this.ckan.module('datatablesview_plus', function (jQuery) {
           // make sure all text is rendered as text in case tables have HTML in them
           {
             targets: '_all',
-            render: DataTable.render.text()
+            //  render: DataTable.render.text();
+            render: function(data, type, row){
+              const regex1 = /T00:00:00$/;
+              const regex2 = /^1899-12-31T/;
+
+              if( data.match(regex1) ||  data.match(regex2) ) {
+                return data.replace( 'T00:00:00', '' ).replace( '1899-12-31T', '' );
+              } else {
+                return escapeHtml( data );
+              }
+              
+            }
+
           }
 
         ],


### PR DESCRIPTION
Force date formatting to be correct when a DateTime either doesn't have a data or a time. This is a temporary fix pending the Date Formatting metadata that DataPusher will provide allowing us to correctly format dates in all cases.